### PR TITLE
Setup avatars with ActiveStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@
 /coverage
 .byebug_history
 .vscode
-/public/*
+public/*
+tmp/
+storage/
+app/assets/builds/*

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'tzinfo-data', platforms: %i[ mswin mswin64 mingw x64_mingw jruby ]
 gem 'bootsnap', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem 'image_processing', '~> 1.2'
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,10 +101,15 @@ GEM
       reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.13.0)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -116,6 +121,7 @@ GEM
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -127,6 +133,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.24.0)
@@ -200,6 +207,9 @@ GEM
       io-console (~> 0.5)
     rexml (3.3.0)
       strscan
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -212,11 +222,14 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    tailwindcss-rails (2.0.31-x86_64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.31-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.1)
@@ -250,12 +263,14 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   bootsnap
   capybara
   debug
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/app/controllers/guest_posts_controller.rb
+++ b/app/controllers/guest_posts_controller.rb
@@ -6,6 +6,7 @@ class GuestPostsController < ApplicationController
 
   def create
     @guestpost = GuestPost.new(guestpost_params)
+    @guestpost.avatar.attach(guestpost_params[:avatar])
 
     if @guestpost.save
       redirect_to guestbook_path
@@ -18,6 +19,6 @@ class GuestPostsController < ApplicationController
   private
 
   def guestpost_params
-    params.require(:guest_post).permit(:author, :title, :body)
+    params.require(:guest_post).permit(:author, :title, :body, :avatar)
   end
 end

--- a/app/models/guest_post.rb
+++ b/app/models/guest_post.rb
@@ -1,4 +1,5 @@
 class GuestPost < ApplicationRecord
   # TODO: implement when ui have indicator that fielcs are required
   # validates :author, :title, :body, presence: true
+  has_one_attached :avatar
 end

--- a/app/views/guest_posts/index.html.erb
+++ b/app/views/guest_posts/index.html.erb
@@ -2,6 +2,13 @@
   <p class="text-lg">You can leave your comments and feedback here =)</p>  
   <%= form_with model: @guestpost, url: guest_posts_path, local: true do |f| %>
     <div class="flex flex-col mt-4">
+      <%= f.label :avatar, class: "label font-bold text-gray-700 mb-1" %>
+      <%= f.file_field :avatar,
+        class: "input input-bordered text-secondary rounded-lg w-full",
+        placeholder: "Upload a nice photo that is not too risquee" %>
+    </div>
+
+    <div class="flex flex-col mt-4">
       <%= f.label :author, class: "label font-bold text-gray-700 mb-1" %>
       <%= f.text_field :author, 
         class: "input input-bordered text-secondary rounded-lg w-full", 
@@ -37,6 +44,10 @@
             <span class="text-sm text-neutral-content"> • <%= post.updated_at.strftime("%d %b %Y") %> </span> 
           </div>
         </div>
+
+        <% if post.avatar %>
+          <%= image_tag post.avatar, class: "rounded-lg" %>
+        <% end %>
 
         <div class="pb-2">
           <h2 class="text-2xl font-medium mb-2"> <%= post.title %> </h2>

--- a/db/migrate/20241023164558_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20241023164558_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_22_193950) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_23_164558) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "guest_posts", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -37,4 +65,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_22_193950) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## [Setup active_storage](https://github.com/calvitoria/rails-portfolio/commit/97a78ba8f3b90dc9beb7bf38881f47215aaa95ab) 
[Active Storage](https://edgeguides.rubyonrails.org/active_storage_overview.html)
is the standard way to handle image uploads with Rails.

We are setting in up in preparation for taking user files and linking
them to guest posts.

## [Allow upload of avatar with guest posts](https://github.com/calvitoria/rails-portfolio/commit/b055dffcd9f16011c9ceb5ea818923b299144640) 

This allows a visitor to attach an avatar image to their post. The image
will then be rendered whenever the post is shown.